### PR TITLE
Don't DNS lookup with every send call.

### DIFF
--- a/lib/camayoc/handlers/statsd.rb
+++ b/lib/camayoc/handlers/statsd.rb
@@ -15,6 +15,7 @@ module Camayoc
         @host = options[:host]
         @port = options[:port]
         @socket = UDPSocket.new
+        @socket.connect(@host, @port)
         self.thread_safe = Camayoc.thread_safe?
       end
 
@@ -50,7 +51,7 @@ module Camayoc
             stat = stat.gsub(Camayoc::DELIMITER,'.')
             msg = "#{prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}"
             synchronize do
-              @socket.send(msg, 0, @host, @port)
+              @socket.send(msg, 0)
             end
           end
         end

--- a/test/handlers/statsd_test.rb
+++ b/test/handlers/statsd_test.rb
@@ -36,7 +36,7 @@ class StatsdTest < Test::Unit::TestCase
 
   private
     def expect_message(message)
-      @statsd.instance_variable_get("@socket").expects(:send).with(message,0,"localhost",1234)
+      @statsd.instance_variable_get("@socket").expects(:send).with(message,0)
     end
 
     def never_expect_message


### PR DESCRIPTION
Dns lookups occur with every send call, which can be slow. Here, the DNS lookup will occur during initialization only.
